### PR TITLE
RS-1980: Add securityContext to Helm chart to fix container insights issue

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/daemonset.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/daemonset.yaml
@@ -32,6 +32,8 @@ spec:
             {{- toYaml .Values.adotCollector.daemonSet.volumeMounts | nindent 12 }}
           resources:
             {{- toYaml .Values.adotCollector.daemonSet.resources | nindent 12 }}
+      securityContext:
+        {{- toYaml .Values.adotCollector.daemonSet.securityContext | nindent 10}}
       volumes:
         {{- toYaml .Values.adotCollector.daemonSet.volumes | nindent 10 }}
       serviceAccountName: {{ .Values.adotCollector.daemonSet.serviceAccount.name  }}

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -33,6 +33,7 @@ adotCollector:
       annotations: {}
     clusterRoleName: "adot-collector-role"
     clusterRoleBindingName: "adot-collector-role-binding"
+    securityContext: {}
     configMap:
       name: "adot-conf"
       app: "opentelemetry"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Adding `securityContext` to Helm chart to set `runAsUser` and `runAsGroup` properties when running on EKS.
See: https://aws-otel.github.io/docs/getting-started/container-insights

**Link to tracking Issue:** 
https://franklin-ai.atlassian.net/browse/RS-1980

**Testing:**
Deployed to Franklin Dev EKS cluster with blank security context and also set security context params `runAsUser` and `runAsGroup`.

**Documentation:** <Describe the documentation added.>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
